### PR TITLE
Node 4.x compatibility patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "jt400",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Implementation http://jt400.sourceforge.net/ on JavaScript",
   "main": "index.js",
   "dependencies": {
-    "java": "^0.4.4",
+    "java": "^0.6.0",
     "string": "^3.0.0"
   },
   "repository": {


### PR DESCRIPTION
update package JSON to use Java 0.6.0 (which makes jt400 compatible with nodejs 4.2)
increased version to 0.1.1