### PR TITLE
Allow calling of stored procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ More info: [http://jt400.sourceforge.net/](http://jt400.sourceforge.net/)
       }
     });
 
+    //CALL stored procedure must use executeStoredProc()
+    var outputParameters = [{
+      Index: 1,
+      DataType: 1
+    }];
+
+    database.executeStoredProc("CALL FOO('BAR',?)", outputParameters);
+
+    database.on('executeStoredProc', function(error, results) {
+      if (error) {
+        console.log(error);
+      }
+      else {
+        console.log(results);
+      }
+    });
 
 # Run
     node app.js

--- a/example/storedProcedure.js
+++ b/example/storedProcedure.js
@@ -1,0 +1,46 @@
+var Database = require('jt400');
+var database = new Database();
+
+var config = {
+  libpath: __dirname + '/jt400.jar',
+  drivername: 'com.ibm.as400.access.AS400JDBCDriver',
+  url: 'jdbc:as400://127.0.0.1/myDatabase;user=myUser;password=myPassword'
+};
+
+database.initialize(config);
+
+//CALL stored procedure must use executeStoredProc()
+// InOut parameters require a value to be provided
+//  in the outputParameters object.  In this example
+//  the first parameter is an InOut parameter, the
+//  second is an Out parameter.  Do not provide a
+//  value for Out parameters.
+//
+// Index values can be an int or a string, if it is
+//  a string it must correspond to the column name in
+//  the stored procedure.
+//
+// DataType must be one of integer values for jdbc sql types in
+//  java.sql.Types.
+var outputParameters = [
+  {
+    Index: 1,
+    DataType: 1,
+    Value: 'a'
+  },
+  {
+    Index: 2,
+    DataType: 1
+  }
+];
+
+database.executeStoredProc("CALL FOO('BAR',?,?)", outputParameters);
+
+database.on('executeStoredProc', function(error, results) {
+  if (error) {
+    console.log(error);
+  }
+  else {
+    console.log(results);
+  }
+});

--- a/lib/jt400.js
+++ b/lib/jt400.js
@@ -179,7 +179,7 @@ Database.prototype.executeStoredProc = function(procedure,outputParams) {
 
           for (i = 0; i < outputParams.length; i++)
           {
-			if("Value" in outputParams[i])
+            if("Value" in outputParams[i])
             {
               callStatement.setString(outputParams[i].Index,outputParams[i].Value,function(setStringError, setString) {
                 if (setStringError) {

--- a/lib/jt400.js
+++ b/lib/jt400.js
@@ -204,7 +204,6 @@ Database.prototype.executeStoredProc = function(procedure,outputParams) {
 
               }
               else {
-                var results = [];
                 var result = {};
                 for (i = 0; i < outputParams.length; i++) {
                   if(i == outputParams.length - 1 )
@@ -212,8 +211,7 @@ Database.prototype.executeStoredProc = function(procedure,outputParams) {
                     result[outputParams[i].Index] = callStatement.getStringSync(outputParams[i].Index).trim();
                   }
                 }
-                results.push(result);
-                self.emit('executeStoredProc', null, results);
+                self.emit('executeStoredProc', null, result);
               }
             });
           }

--- a/lib/jt400.js
+++ b/lib/jt400.js
@@ -62,7 +62,7 @@ Database.prototype.close = function() {
 };
 
 /**
-* Excute Update
+* Execute Update
 */
 Database.prototype.executeUpdate = function(sql) {
   var self = this;
@@ -95,7 +95,7 @@ Database.prototype.executeUpdate = function(sql) {
 };
 
 /**
-* Excute
+* Execute
 */
 Database.prototype.execute = function(sql) {
   var self = this;
@@ -155,6 +155,75 @@ Database.prototype.execute = function(sql) {
     }
   });
 };
+
+/**
+* Execute stored procedure
+* Output parameters must be passed in the following form:
+* [{Index: [index value], DataType: [SQL datatype as int], [Value: InOut Parameter Input Value] }, { ...}]
+*/
+Database.prototype.executeStoredProc = function(procedure,outputParams) {
+  var self = this;
+
+  java.callStaticMethod('java.sql.DriverManager', 'getConnection', self._config.url, function(getConnectionError, conn) {
+    if (getConnectionError) {
+      self.emit('executeStoredProc', getConnectionError, null);
+    } else {
+
+      conn.prepareCall(procedure,function(prepareCallError, callStatement) {
+        if (prepareCallError) {
+          self.emit('executeStoredProc', prepareCallError, null);
+
+        }
+        else {
+          var error = false;
+
+          for (i = 0; i < outputParams.length; i++)
+          {
+			if("Value" in outputParams[i])
+            {
+              callStatement.setString(outputParams[i].Index,outputParams[i].Value,function(setStringError, setString) {
+                if (setStringError) {
+                  self.emit('executeStoredProc', setStringError, null);
+
+                  error = true;
+                }
+              });
+            }
+
+            callStatement.registerOutParameter(outputParams[i].Index, outputParams[i].DataType,function(registerOutParameterError) {
+              if (registerOutParameterError) {
+                self.emit('executeStoredProc',registerParameterError, null);
+              }
+            });
+          }
+          if(error == false)
+          {
+            callStatement.execute(function(executeError, resultString) {
+              if (executeError) {
+                self.emit('executeStoredProc', executeError, null);
+
+              }
+              else {
+                var results = [];
+                var result = {};
+                for (i = 0; i < outputParams.length; i++) {
+                  if(i == outputParams.length - 1 )
+                  {
+                    result[outputParams[i].Index] = callStatement.getStringSync(outputParams[i].Index).trim();
+                  }
+                }
+                results.push(result);
+                self.emit('executeStoredProc', null, results);
+              }
+            });
+          }
+        }
+      });
+    }
+  });
+}
+
+
 
 /**
 * Export object class


### PR DESCRIPTION
Calling stored procedures that have Out/InOut parameters in Java requires preparing a CallableStatement, and registering the parameter via the registerOutParameter() method, and for InOut parameters, using the setString() method to set the InOut parameter's value.  This pull request allows calling stored procedures that have Out/InOut parameters.

There are multiple ways to set values for a parameter, based on the data type (setString, setInt, setByte, etc).  This pull request only implements setString for InOut parameters, other value-setting methods are not yet implemented here.